### PR TITLE
Add failing case

### DIFF
--- a/src/test/java/pl/dziedziul/optionalDeserializationExample/DeserializationTest.java
+++ b/src/test/java/pl/dziedziul/optionalDeserializationExample/DeserializationTest.java
@@ -2,6 +2,8 @@ package pl.dziedziul.optionalDeserializationExample;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import lombok.Value;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,11 +33,28 @@ class DeserializationTest {
                 "}", GetTransferResponse.class);
         assertThat(getTransferResponse.getMaybeString()).hasValue("some-string");
     }
+
+    @Test
+    public void shouldDeserializeClassWithOptionalFieldWrappedWithAnotherOne() throws JsonProcessingException {
+        OuterResponse outerResponse = mapper.readValue("{\"transferResponse\":" +
+                        "{\n" +
+                        "  \"id\": \"some-id\"\n" +
+                        "}" +
+                "}", OuterResponse.class);
+        assertThat(outerResponse.getTransferResponse().getMaybeString()).isEmpty();
+    }
 }
 
 
 @Value
+//@NoArgsConstructor(force = true,access = AccessLevel.PRIVATE)
 class GetTransferResponse {
     private final String id;
     private final Optional<String> maybeString;
+}
+
+@Value
+//@NoArgsConstructor(force = true,access = AccessLevel.PRIVATE)
+class OuterResponse {
+    private final GetTransferResponse transferResponse;
 }


### PR DESCRIPTION
As soon as I wrap class with optional property with another one jackson fails to deserialize it. Adding `NoArgsConstructor` helps for creation failure but optional property is broken again.